### PR TITLE
Fix sorting of torrents

### DIFF
--- a/enhancedtorrentview.user.js
+++ b/enhancedtorrentview.user.js
@@ -4,7 +4,7 @@
 // @namespace   Megure@AnimeBytes.tv
 // @description Shows how much yen you would receive if you seeded torrents; shows required seeding time; allows sorting and filtering of torrent tables; dynamic loading of transfer history tables
 // @include     http*://animebytes.tv*
-// @version     1.00
+// @version     1.01
 // @grant       GM_getValue
 // @grant       GM_setValue
 // @icon        http://animebytes.tv/favicon.ico
@@ -88,7 +88,7 @@
         return row;
     }
     function get_corresponding_torrent_row(row) {
-        var anchor = row.querySelector('a[title="Download"]');
+        var anchor = row.querySelector('a[title="Report"]');
         if (anchor !== null) {
             var match = anchor.href.match(/id=(\d+)/i);
             if (match !== null) {


### PR DESCRIPTION
Because the website changed its code, the torrent description rows were not properly associated with the torrent rows and not placed correctly to be opened below the torrent row after sorting, but instead remained to be opened at the top of the table.